### PR TITLE
Update jquery-fix.js for DataTable allowed tags

### DIFF
--- a/src/core/dep/jquery-fix.js
+++ b/src/core/dep/jquery-fix.js
@@ -171,10 +171,8 @@ var localParseHTML = jQuery.parseHTML,
 	replaceWith = jQuery.fn.replaceWith,
 	jqInit = jQuery.fn.init,
 	dataTableAllowedTag = [
-		"<tbody/>",
-		"<tr/>",
-		"<td />",
-		"<td/>"
+		"<tbody>", "<tr>", "<td>", "<td>",
+		"</tbody>", "</tr>", "</td>", "</td>"
 	],
 	sanitize = function( html ) {
 


### PR DESCRIPTION
DataTable allowed Tag array has html tags that are non-existant.

This updates the datatable tags to what they should be.

Specifically allows dynamically adding rows to a DataTable.

**Related issues / Requêtes associées**
https://github.com/wet-boew/wet-boew/issues/9293
https://github.com/wet-boew/wet-boew/issues/9610

Original commit that caused this issue:
https://github.com/wet-boew/wet-boew/commit/581e1652b8f9130f27a4d8a32fd8d47d651d5a32

